### PR TITLE
feat: add ability to skip available appointments

### DIFF
--- a/src/main/java/ru/kusok_piroga/gorzdravbot/SkipAppointmentEntity.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/SkipAppointmentEntity.java
@@ -1,0 +1,44 @@
+package ru.kusok_piroga.gorzdravbot;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ru.kusok_piroga.gorzdravbot.domain.models.TaskEntity;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "skip_appointment")
+@AllArgsConstructor
+@NoArgsConstructor
+public class SkipAppointmentEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "task_id", nullable = false)
+    private TaskEntity task;
+
+    @Column(name = "appointment_id", nullable = false)
+    private String appointmentId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SkipAppointmentEntity that = (SkipAppointmentEntity) o;
+        return getTask().equals(that.getTask()) && getAppointmentId().equals(that.getAppointmentId());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getTask().hashCode();
+        result = 31 * result + getAppointmentId().hashCode();
+        return result;
+    }
+}

--- a/src/main/java/ru/kusok_piroga/gorzdravbot/SkipAppointmentRepository.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/SkipAppointmentRepository.java
@@ -1,0 +1,6 @@
+package ru.kusok_piroga.gorzdravbot;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface SkipAppointmentRepository extends CrudRepository<SkipAppointmentEntity, Long> {
+}

--- a/src/main/java/ru/kusok_piroga/gorzdravbot/bot/callbacks/dto/SkipAppointmentDto.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/bot/callbacks/dto/SkipAppointmentDto.java
@@ -1,0 +1,30 @@
+package ru.kusok_piroga.gorzdravbot.bot.callbacks.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Optional;
+
+/**
+ * DTO for {@link ru.kusok_piroga.gorzdravbot.bot.callbacks.units.SkipAppointmentCallbackUnit}
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SkipAppointmentDto(Long taskId, String appointmentId) {
+    public static Optional<SkipAppointmentDto> parse(String data){
+        try {
+            return Optional.of(new ObjectMapper().readValue(data, SkipAppointmentDto.class));
+        } catch (JsonProcessingException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return new ObjectMapper().writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            return "";
+        }
+    }
+}

--- a/src/main/java/ru/kusok_piroga/gorzdravbot/bot/callbacks/units/SkipAppointmentCallbackUnit.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/bot/callbacks/units/SkipAppointmentCallbackUnit.java
@@ -1,0 +1,70 @@
+package ru.kusok_piroga.gorzdravbot.bot.callbacks.units;
+
+import io.github.drednote.telegram.response.GenericTelegramResponse;
+import io.github.drednote.telegram.response.TelegramResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import ru.kusok_piroga.gorzdravbot.SkipAppointmentRepository;
+import ru.kusok_piroga.gorzdravbot.bot.callbacks.dto.SkipAppointmentDto;
+import ru.kusok_piroga.gorzdravbot.bot.callbacks.models.CallbackData;
+import ru.kusok_piroga.gorzdravbot.producer.services.TaskService;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SkipAppointmentCallbackUnit extends BaseCallbackUnit {
+
+    private final TaskService taskService;
+    private final SkipAppointmentRepository skipAppointmentRepository;
+
+    public static final String FN_SKIP = "skip_appntmt";
+
+    @Override
+    public TelegramResponse execute(CallbackData data) {
+        if (!checkAffiliation(data.fn())) {
+            return getNext().execute(data);
+        }
+
+        log.info("Callback, fn = {}, data = {}", data.fn(), data.d());
+
+        switch (data.fn()) {
+            case FN_SKIP:
+                Optional<SkipAppointmentDto> skipAppointmentDto = SkipAppointmentDto.parse(data.d());
+                if (skipAppointmentDto.isEmpty()) {
+                    log.error("Callback wrong format");
+                    return new GenericTelegramResponse("Ошибка значения callback");
+                }
+
+                boolean result = taskService.skipAppointment(
+                  skipAppointmentDto.get().taskId(),
+                  skipAppointmentDto.get().appointmentId()
+                );
+
+                if (result){
+                    return new GenericTelegramResponse("Номерок '%s' добавлен в список пропускаемых номерков"
+                            .formatted(skipAppointmentDto.get().appointmentId()));
+                } else {
+                    log.error("Fail add '{}' to skip list for task '{}'",
+                            skipAppointmentDto.get().taskId(),
+                            skipAppointmentDto.get().appointmentId());
+                    return new GenericTelegramResponse("Не удалось добавить '%s' в список пропускаемых номерков"
+                            .formatted(skipAppointmentDto.get().appointmentId()));
+                }
+            default:
+                log.warn("Callback unknown fn");
+                return new GenericTelegramResponse("Ошибка значения callback");
+        }
+    }
+
+    private boolean checkAffiliation(String function) {
+        switch (function) {
+            case FN_SKIP:
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/src/main/java/ru/kusok_piroga/gorzdravbot/bot/services/TaskListCommandService.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/bot/services/TaskListCommandService.java
@@ -7,6 +7,7 @@ import io.github.drednote.telegram.response.TelegramResponse;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
+import ru.kusok_piroga.gorzdravbot.SkipAppointmentEntity;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.units.TaskCallbackUnit;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.utils.CallbackEncoder;
 import ru.kusok_piroga.gorzdravbot.bot.exceptions.EmptyTaskListException;
@@ -35,7 +36,9 @@ public class TaskListCommandService implements ICommandService {
             Поликлиника: %s
             Специалист: %s
             Врач: %s
-            Номерок: %s""";
+            Номерок: %s
+            Пропускаются номерки:
+            %s""";
 
     @Override
     public TelegramResponse processCommand(UpdateRequest request) {
@@ -128,7 +131,13 @@ public class TaskListCommandService implements ICommandService {
                         (task.getRecordedAppointmentId() == null) ?
                                 "не взят"
                                 :
-                                task.getRecordedAppointmentId()
+                                task.getRecordedAppointmentId(),
+                        (task.getSkippedAppointments().isEmpty()) ?
+                                "нет"
+                                :
+                                task.getSkippedAppointments().stream()
+                                        .map(SkipAppointmentEntity::getAppointmentId)
+                                        .toList().toString()
                 ),
                 List.of(buttons)
         );

--- a/src/main/java/ru/kusok_piroga/gorzdravbot/domain/models/TaskEntity.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/domain/models/TaskEntity.java
@@ -4,10 +4,13 @@ import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import ru.kusok_piroga.gorzdravbot.SkipAppointmentEntity;
 import ru.kusok_piroga.gorzdravbot.domain.repositories.converters.TaskDateLimitsConverter;
 import ru.kusok_piroga.gorzdravbot.domain.repositories.converters.TaskTimeLimitsConverter;
 
 import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 @Entity
 @Table(name="tasks")
@@ -47,4 +50,7 @@ public class TaskEntity {
 
     @Nonnull
     private Boolean completed = false;
+
+    @OneToMany(mappedBy = "task", orphanRemoval = true, fetch = FetchType.EAGER)
+    private Set<SkipAppointmentEntity> skippedAppointments = new LinkedHashSet<>();
 }

--- a/src/main/java/ru/kusok_piroga/gorzdravbot/producer/services/TaskService.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/producer/services/TaskService.java
@@ -3,6 +3,8 @@ package ru.kusok_piroga.gorzdravbot.producer.services;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import ru.kusok_piroga.gorzdravbot.SkipAppointmentEntity;
+import ru.kusok_piroga.gorzdravbot.SkipAppointmentRepository;
 import ru.kusok_piroga.gorzdravbot.api.services.ApiService;
 import ru.kusok_piroga.gorzdravbot.domain.exceptions.DateLimitParseException;
 import ru.kusok_piroga.gorzdravbot.domain.exceptions.TimeLimitParseException;
@@ -25,6 +27,7 @@ public class TaskService {
     private final ApiService api;
     private final TaskRepository repository;
     private final PatientService patientService;
+    private final SkipAppointmentRepository skipAppointmentRepository;
 
     private final Map<TaskState, TaskFieldFiller> taskFillers = Map.of(
             SET_DISTRICT, new DistrictFiller(),
@@ -204,5 +207,20 @@ public class TaskService {
                 throw  new DateFormatException();
             }
         }
+    }
+
+    public boolean skipAppointment(Long taskId, String appointmentId){
+
+        Optional<TaskEntity> task = repository.findById(taskId);
+
+        if (task.isEmpty()) return false;
+
+        SkipAppointmentEntity skipAppointment = new SkipAppointmentEntity();
+        skipAppointment.setAppointmentId(appointmentId);
+        skipAppointment.setTask(task.get());
+
+        skipAppointmentRepository.save(skipAppointment);
+
+        return true;
     }
 }

--- a/src/main/java/ru/kusok_piroga/gorzdravbot/recorder/services/NotifyService.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/recorder/services/NotifyService.java
@@ -2,17 +2,18 @@ package ru.kusok_piroga.gorzdravbot.recorder.services;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.springframework.stereotype.Service;
 import ru.kusok_piroga.gorzdravbot.api.models.AvailableAppointment;
+import ru.kusok_piroga.gorzdravbot.bot.callbacks.dto.SkipAppointmentDto;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.units.RecordCallbackUnit;
+import ru.kusok_piroga.gorzdravbot.bot.callbacks.units.SkipAppointmentCallbackUnit;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.utils.CallbackEncoder;
 import ru.kusok_piroga.gorzdravbot.bot.services.RawSendService;
 import ru.kusok_piroga.gorzdravbot.domain.models.TaskEntity;
 import ru.kusok_piroga.gorzdravbot.recorder.models.NotifyToChatData;
 
-import java.util.Calendar;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static ru.kusok_piroga.gorzdravbot.recorder.services.RecordService.DELAY_FOR_RECORD_UNIT;
 import static ru.kusok_piroga.gorzdravbot.recorder.services.RecordService.DELAY_FOR_RECORD_VALUE;
@@ -32,22 +33,50 @@ public class NotifyService {
     public boolean notifyToChat(TaskEntity task, List<AvailableAppointment> availableAppointments) {
         sendService.sendMessage(
                 task.getDialogId(),
-                "Выберите доступное время. Через %s %s будет автоматически произведена запись на %s"
-                        .formatted(
-                                DELAY_FOR_RECORD_VALUE,
-                                (DELAY_FOR_RECORD_UNIT == Calendar.MINUTE) ? "мин." : "ед. времени",
-                                getPrintableAppointmentDateTime(availableAppointments.get(0).visitStart())),
-                availableAppointments.stream()
-                        .map(availableAppointment ->
-                                Map.of(
-                                        getPrintableAppointmentDateTime(availableAppointment.visitStart()),
-                                        callbackEncoder.encode(
-                                                RecordCallbackUnit.FN_RECORD,
-                                                new NotifyToChatData(task.getId(), availableAppointment.id())
-                                        )
-                                )
-                        ).toList()
+                appointmentText(availableAppointments),
+                appointmentButtons(task, availableAppointments)
         );
         return true;
+    }
+
+    private String appointmentText(List<AvailableAppointment> availableAppointments){
+        return "Выберите доступное время. Через %s %s будет автоматически произведена запись на %s. 'X' - пропустить"
+                .formatted(
+                        DELAY_FOR_RECORD_VALUE,
+                        (DELAY_FOR_RECORD_UNIT == Calendar.MINUTE) ? "мин." : "ед. времени",
+                        getPrintableAppointmentDateTime(availableAppointments.get(0).visitStart()));
+    }
+
+    private List<Map<String, String>> appointmentButtons(TaskEntity task, List<AvailableAppointment> availableAppointments){
+        List<Map<String, String>> buttons = new ArrayList<>();
+        for (val availableAppointment: availableAppointments){
+            buttons.add(new LinkedHashMap<>());
+            buttons.get(buttons.size()-1).putAll(
+                    appointmentRecordButton(task, availableAppointment)
+            );
+            buttons.get(buttons.size()-1).putAll(
+                    appointmentSkipButton(task, availableAppointment)
+            );
+        }
+        return buttons;
+    }
+
+    private Map<String, String> appointmentRecordButton(TaskEntity task, AvailableAppointment availableAppointment){
+        return Map.of(
+                getPrintableAppointmentDateTime(availableAppointment.visitStart()),
+                callbackEncoder.encode(
+                        RecordCallbackUnit.FN_RECORD,
+                        new NotifyToChatData(task.getId(), availableAppointment.id())
+                )
+        );
+    }
+    private Map<String, String> appointmentSkipButton(TaskEntity task, AvailableAppointment availableAppointment){
+        return Map.of(
+                "X",
+                callbackEncoder.encode(
+                        SkipAppointmentCallbackUnit.FN_SKIP,
+                        new SkipAppointmentDto(task.getId(), availableAppointment.id())
+                )
+        );
     }
 }

--- a/src/main/java/ru/kusok_piroga/gorzdravbot/recorder/utils/ConstraintChecker.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/recorder/utils/ConstraintChecker.java
@@ -1,6 +1,7 @@
 package ru.kusok_piroga.gorzdravbot.recorder.utils;
 
 import lombok.experimental.UtilityClass;
+import ru.kusok_piroga.gorzdravbot.SkipAppointmentEntity;
 import ru.kusok_piroga.gorzdravbot.api.models.AvailableAppointment;
 import ru.kusok_piroga.gorzdravbot.domain.models.TaskDateLimits;
 import ru.kusok_piroga.gorzdravbot.domain.models.TaskEntity;
@@ -12,12 +13,13 @@ import java.time.format.DateTimeParseException;
 
 @UtilityClass
 public class ConstraintChecker {
-    public static boolean check(TaskEntity task, AvailableAppointment appointment){
+    public static boolean check(TaskEntity task, AvailableAppointment appointment) {
         return checkLimitConstraint(
                 appointment.visitStart(),
                 task.getTimeLimits(),
                 task.getDateLimits()
-        );
+        ) &&
+               checkIsNotSkipped(task, appointment);
     }
 
     private static boolean checkLimitConstraint(String visitStart, TaskTimeLimits timeLimits, TaskDateLimits dateLimits) {
@@ -31,5 +33,12 @@ public class ConstraintChecker {
         } catch (DateTimeParseException e) {
             return false;
         }
+    }
+
+    private static boolean checkIsNotSkipped(TaskEntity task, AvailableAppointment appointment) {
+        SkipAppointmentEntity toCheck = new SkipAppointmentEntity();
+        toCheck.setTask(task);
+        toCheck.setAppointmentId(appointment.id());
+        return !task.getSkippedAppointments().contains(toCheck);
     }
 }

--- a/src/main/resources/db/changelog/changelogs/02-add-skip-appointments.sql
+++ b/src/main/resources/db/changelog/changelogs/02-add-skip-appointments.sql
@@ -1,0 +1,10 @@
+CREATE TABLE skip_appointment
+(
+    id             BIGSERIAL PRIMARY KEY,
+    task_id        BIGINT       NOT NULL,
+    appointment_id VARCHAR(255) NOT NULL
+);
+
+ALTER TABLE skip_appointment
+    ADD CONSTRAINT FK_SKIP_APPOINTMENT_ON_TASK FOREIGN KEY (task_id) REFERENCES tasks (id);
+

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -11,5 +11,11 @@ databaseChangeLog:
       changes:
         - sqlFile:
             path: db/changelog/changelogs/01-new-task-limits.sql
+  - changeSet:
+      id:  add-skip-appointments
+      author:  elisevgeniy
+      changes:
+        - sqlFile:
+            path: db/changelog/changelogs/02-add-skip-appointments.sql
 
 

--- a/src/test/java/ru/kusok_piroga/gorzdravbot/recorder/utils/ConstraintCheckerTest.java
+++ b/src/test/java/ru/kusok_piroga/gorzdravbot/recorder/utils/ConstraintCheckerTest.java
@@ -1,6 +1,7 @@
 package ru.kusok_piroga.gorzdravbot.recorder.utils;
 
 import org.junit.jupiter.api.Test;
+import ru.kusok_piroga.gorzdravbot.SkipAppointmentEntity;
 import ru.kusok_piroga.gorzdravbot.api.models.AvailableAppointment;
 import ru.kusok_piroga.gorzdravbot.domain.exceptions.DateLimitParseException;
 import ru.kusok_piroga.gorzdravbot.domain.exceptions.TimeLimitParseException;
@@ -8,12 +9,14 @@ import ru.kusok_piroga.gorzdravbot.domain.models.TaskDateLimits;
 import ru.kusok_piroga.gorzdravbot.domain.models.TaskEntity;
 import ru.kusok_piroga.gorzdravbot.domain.models.TaskTimeLimits;
 
+import java.util.Set;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ConstraintCheckerTest {
 
     @Test
-    void check_valid_data() throws TimeLimitParseException, DateLimitParseException {
+    void check_valid_time_data() throws TimeLimitParseException, DateLimitParseException {
         TaskEntity task = new TaskEntity();
         task.setTimeLimits(new TaskTimeLimits("10:00-12:00"));
         task.setDateLimits(new TaskDateLimits("10.10.2024-03.12.2025"));
@@ -57,6 +60,56 @@ class ConstraintCheckerTest {
                 "",
                 "2026-11-26T11:35:00",
                 "2026-11-26T11:55:00",
+                "",
+                "",
+                ""
+        );
+
+        assertThat(ConstraintChecker.check(task, appointment))
+                .isFalse();
+    }
+
+    @Test
+    void check_valid_skip_data() throws TimeLimitParseException, DateLimitParseException {
+        TaskEntity task = new TaskEntity();
+        task.setTimeLimits(new TaskTimeLimits(""));
+        task.setDateLimits(new TaskDateLimits("10.10.2000-03.12.3000"));
+        task.setSkippedAppointments(Set.of(
+                new SkipAppointmentEntity(
+                        1L,
+                        task,
+                        "1234"
+                )
+        ));
+        AvailableAppointment appointment = new AvailableAppointment(
+                "123",
+                "2024-11-26T11:35:00",
+                "2024-11-26T11:55:00",
+                "",
+                "",
+                ""
+        );
+
+        assertThat(ConstraintChecker.check(task, appointment))
+                .isTrue();
+    }
+
+    @Test
+    void check_fail_by_skip_data() throws TimeLimitParseException, DateLimitParseException {
+        TaskEntity task = new TaskEntity();
+        task.setTimeLimits(new TaskTimeLimits(""));
+        task.setDateLimits(new TaskDateLimits("10.10.2000-03.12.3000"));
+        task.setSkippedAppointments(Set.of(
+                new SkipAppointmentEntity(
+                        1L,
+                        task,
+                        "123"
+                )
+        ));
+        AvailableAppointment appointment = new AvailableAppointment(
+                "123",
+                "2024-11-26T11:35:00",
+                "2024-11-26T11:55:00",
                 "",
                 "",
                 ""


### PR DESCRIPTION
Now, when checking restrictions for available numbers, their presence in the list of skipped numbers will be taken into account.