### PR TITLE
feat: add fast record mode

### DIFF
--- a/src/main/java/ru/kusok_piroga/gorzdravbot/bot/callbacks/dto/FastRecordTaskDto.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/bot/callbacks/dto/FastRecordTaskDto.java
@@ -10,10 +10,10 @@ import java.util.Optional;
  * DTO for change {@link ru.kusok_piroga.gorzdravbot.domain.models.TaskEntity}
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record ChangeTaskDto(Long taskId) {
-    public static Optional<ChangeTaskDto> parse(String data){
+public record FastRecordTaskDto(Long taskId){
+    public static Optional<FastRecordTaskDto> parse(String data){
         try {
-            return Optional.of(new ObjectMapper().readValue(data, ChangeTaskDto.class));
+            return Optional.of(new ObjectMapper().readValue(data, FastRecordTaskDto.class));
         } catch (JsonProcessingException e) {
             return Optional.empty();
         }

--- a/src/main/java/ru/kusok_piroga/gorzdravbot/bot/callbacks/units/TaskCallbackUnit.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/bot/callbacks/units/TaskCallbackUnit.java
@@ -8,15 +8,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.dto.ChangeTaskDto;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.dto.CopyTaskDto;
+import ru.kusok_piroga.gorzdravbot.bot.callbacks.dto.FastRecordTaskDto;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.dto.RestartTaskDto;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.models.CallbackData;
 import ru.kusok_piroga.gorzdravbot.bot.models.Commands;
 import ru.kusok_piroga.gorzdravbot.bot.models.dto.TaskCopyDto;
+import ru.kusok_piroga.gorzdravbot.bot.models.dto.TaskFastRecordDto;
 import ru.kusok_piroga.gorzdravbot.bot.responses.DeleteMessageTelegramResponse;
-import ru.kusok_piroga.gorzdravbot.bot.services.TaskCancelCommandService;
-import ru.kusok_piroga.gorzdravbot.bot.services.TaskCreateCommandService;
-import ru.kusok_piroga.gorzdravbot.bot.services.TaskDeleteCommandService;
-import ru.kusok_piroga.gorzdravbot.bot.services.TaskRestartCommandService;
+import ru.kusok_piroga.gorzdravbot.bot.services.*;
 
 import java.util.Optional;
 
@@ -29,12 +28,14 @@ public class TaskCallbackUnit extends BaseCallbackUnit {
     private final TaskCancelCommandService taskCancelCommandService;
     private final TaskRestartCommandService taskRestartCommandService;
     private final TaskCreateCommandService taskCreateCommandService;
+    private final TaskChangeCommandService taskChangeCommandService;
 
     public static final String FN_DELETE = "tsk_del";
     public static final String FN_RESTART = "tsk_up";
     public static final String FN_CANCEL = "tsk_cnl";
     public static final String FN_CHANGE = "tsk_cng";
     public static final String FN_COPY = "tsk_cp";
+    public static final String FN_FAST_RECORD = "tsk_fstrcrd";
 
     @Override
     public TelegramResponse execute(Long dialogId, CallbackData data) {
@@ -104,6 +105,16 @@ public class TaskCallbackUnit extends BaseCallbackUnit {
                 } else {
                     return new GenericTelegramResponse("Задание не скопировано!");
                 }
+            case FN_FAST_RECORD:
+                Optional<FastRecordTaskDto> fastRecordTaskDto = FastRecordTaskDto.parse(data.d());
+                if (fastRecordTaskDto.isEmpty()) {
+                    log.error("Callback wrong format");
+                    return new GenericTelegramResponse("Ошибка значения callback");
+                }
+                return taskChangeCommandService.changeFastRecord(new TaskFastRecordDto(
+                        dialogId,
+                        fastRecordTaskDto.get().taskId()
+                ));
             default:
                 return new GenericTelegramResponse("Ошибка значения callback");
         }

--- a/src/main/java/ru/kusok_piroga/gorzdravbot/bot/models/dto/TaskFastRecordDto.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/bot/models/dto/TaskFastRecordDto.java
@@ -1,0 +1,12 @@
+package ru.kusok_piroga.gorzdravbot.bot.models.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.io.Serializable;
+
+/**
+ * dto for {@link ru.kusok_piroga.gorzdravbot.domain.models.TaskEntity}
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TaskFastRecordDto(Long dialogId, Long taskId) implements Serializable {
+}

--- a/src/main/java/ru/kusok_piroga/gorzdravbot/bot/services/TaskChangeCommandService.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/bot/services/TaskChangeCommandService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import ru.kusok_piroga.gorzdravbot.bot.exceptions.AccessDeniedException;
 import ru.kusok_piroga.gorzdravbot.bot.models.dto.TaskChangeDateDto;
 import ru.kusok_piroga.gorzdravbot.bot.models.dto.TaskChangeTimeDto;
+import ru.kusok_piroga.gorzdravbot.bot.models.dto.TaskFastRecordDto;
 import ru.kusok_piroga.gorzdravbot.producer.services.TaskService;
 
 @Service
@@ -53,6 +54,29 @@ public class TaskChangeCommandService implements ICommandService {
             return new GenericTelegramResponse("Ограничение изменено");
         } else {
             return new GenericTelegramResponse("Ограничение не изменено!");
+        }
+    }
+
+    /**
+     * <p>
+     *     Switch task notification status.
+     *     Fast recording means that notification has already been sent and next appointments check will make record
+     * </p>
+     * @param taskFastRecordDto
+     * @return telegram message contains current Fast Record status
+     */
+    public TelegramResponse changeFastRecord(TaskFastRecordDto taskFastRecordDto) {
+        if (!taskService.validateTaskIdByDialogId(
+                taskFastRecordDto.taskId(),
+                taskFastRecordDto.dialogId()
+        )) {
+            throw new AccessDeniedException();
+        }
+
+        if (taskService.switchNotificationStatus(taskFastRecordDto.taskId())){
+            return new GenericTelegramResponse("При появлении номерка бот сразу Вас запишет");
+        } else {
+            return new GenericTelegramResponse("При появлении номерка бот направит Вам уведомление");
         }
     }
 }

--- a/src/main/java/ru/kusok_piroga/gorzdravbot/bot/services/TaskListCommandService.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/bot/services/TaskListCommandService.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.dto.ChangeTaskDto;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.dto.CopyTaskDto;
+import ru.kusok_piroga.gorzdravbot.bot.callbacks.dto.FastRecordTaskDto;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.dto.RestartTaskDto;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.units.TaskCallbackUnit;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.utils.CallbackEncoder;
@@ -122,6 +123,16 @@ public class TaskListCommandService implements ICommandService {
                 ));
     }
 
+    private void addFastRecordCallbackButton(TaskEntity task, Map<String, String> buttons) {
+        buttons.put(
+                task.getLastNotify() == null ? "Вкл" : "Выкл"
+                        + ". мгновенную запись",
+                callbackEncoder.encode(
+                        TaskCallbackUnit.FN_FAST_RECORD,
+                        new FastRecordTaskDto(task.getId())
+                ));
+    }
+
     private TelegramResponse prepareCompletedTaskMessage(TaskEntity task){
         List<Map<String, String>> buttons = new ArrayList<>();
         buttons.add(new LinkedHashMap<>());
@@ -143,9 +154,11 @@ public class TaskListCommandService implements ICommandService {
         List<Map<String, String>> buttons = new ArrayList<>();
         buttons.add(new LinkedHashMap<>());
         buttons.add(new LinkedHashMap<>());
+        buttons.add(new LinkedHashMap<>());
         addChangeCallbackButton(task, buttons.get(0));
         addCopyCallbackButton(task, buttons.get(0));
         addDeleteCallbackButton(task, buttons.get(1));
+        addFastRecordCallbackButton(task, buttons.get(2));
         return formTaskCallbackButton(task, buttons);
     }
 

--- a/src/main/java/ru/kusok_piroga/gorzdravbot/producer/services/TaskService.java
+++ b/src/main/java/ru/kusok_piroga/gorzdravbot/producer/services/TaskService.java
@@ -12,6 +12,7 @@ import ru.kusok_piroga.gorzdravbot.domain.repositories.SkipAppointmentRepository
 import ru.kusok_piroga.gorzdravbot.domain.repositories.TaskRepository;
 import ru.kusok_piroga.gorzdravbot.producer.exceptions.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -304,5 +305,31 @@ public class TaskService {
 
         repository.save(newTask);
         return true;
+    }
+
+    /**
+     * <p>
+     *     Switch task notification status.
+     *     If notification has already been sent, it is reset to null.
+     *     If notification was not sent, it is set 1 year earlier than the current time.
+     * </p>
+     * @param taskId task id
+     * @return <code>true</code> if notification has already been sent earlier, <code>false</code> otherwise
+     */
+    @Transactional
+    public boolean switchNotificationStatus(Long taskId){
+        TaskEntity task = repository.findById(taskId).orElseThrow(() -> {
+            log.warn("Switch notification status task fail. Task id = {} not found", taskId);
+            return new NoSuchElementException();
+        });
+        if (task.getLastNotify() == null){
+            task.setLastNotify(LocalDateTime.now().minusYears(1));
+            repository.save(task);
+            return true;
+        } else {
+            task.setLastNotify(null);
+            repository.save(task);
+            return false;
+        }
     }
 }

--- a/src/test/java/ru/kusok_piroga/gorzdravbot/bot/callbacks/units/TaskCallbackUnitTest.java
+++ b/src/test/java/ru/kusok_piroga/gorzdravbot/bot/callbacks/units/TaskCallbackUnitTest.java
@@ -9,10 +9,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import ru.kusok_piroga.gorzdravbot.api.services.ApiService;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.dto.RestartTaskDto;
 import ru.kusok_piroga.gorzdravbot.bot.callbacks.models.CallbackData;
-import ru.kusok_piroga.gorzdravbot.bot.services.TaskCancelCommandService;
-import ru.kusok_piroga.gorzdravbot.bot.services.TaskCreateCommandService;
-import ru.kusok_piroga.gorzdravbot.bot.services.TaskDeleteCommandService;
-import ru.kusok_piroga.gorzdravbot.bot.services.TaskRestartCommandService;
+import ru.kusok_piroga.gorzdravbot.bot.services.*;
 import ru.kusok_piroga.gorzdravbot.domain.models.PatientEntity;
 import ru.kusok_piroga.gorzdravbot.domain.models.TaskEntity;
 import ru.kusok_piroga.gorzdravbot.domain.repositories.SkipAppointmentRepository;
@@ -43,9 +40,10 @@ class TaskCallbackUnitTest {
     TaskCancelCommandService taskCancelCommandService;
     @MockitoBean
     TaskCreateCommandService taskCreateCommandService;
-
     @Autowired
     TaskRestartCommandService taskRestartCommandService;
+    @MockitoBean
+    TaskChangeCommandService taskChangeCommandService;
 
     @MockitoBean
     ApiService api;

--- a/src/test/java/ru/kusok_piroga/gorzdravbot/producer/services/TaskServiceTest.java
+++ b/src/test/java/ru/kusok_piroga/gorzdravbot/producer/services/TaskServiceTest.java
@@ -23,6 +23,7 @@ import ru.kusok_piroga.gorzdravbot.producer.exceptions.TimeFormatException;
 import ru.kusok_piroga.gorzdravbot.producer.exceptions.WrongPolyclinicForPatientException;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -303,5 +304,27 @@ class TaskServiceTest {
         )).isFalse();
 
         verify(taskRepository, times(0)).save(any(TaskEntity.class));
+    }
+
+    @Test
+    void switchNotificationStatus() {
+        TaskEntity task = taskRepository.findById(1L).orElseThrow();
+        task.setLastNotify(null);
+        boolean result = taskService.switchNotificationStatus(task.getId());
+
+        assertThat(result).isTrue();
+        assertThat(task.getLastNotify())
+                .isNotNull()
+                .isBefore(LocalDateTime.now().minusMinutes(5));
+        verify(taskRepository, times(1)).save(task);
+
+
+        task.setLastNotify(LocalDateTime.now());
+        result = taskService.switchNotificationStatus(task.getId());
+
+        assertThat(result).isFalse();
+        assertThat(task.getLastNotify())
+                .isNull();
+        verify(taskRepository, times(2)).save(task);
     }
 }


### PR DESCRIPTION
Adds button to task list, which enable or disable Fast Record mode.
Fast Record means that the bot will not notify the user about available appointments and will record immediately